### PR TITLE
Migrate from master/slave language

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -50,8 +50,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'LavaFlow'

--- a/lavaFlow/views.py
+++ b/lavaFlow/views.py
@@ -362,8 +362,8 @@ OPENLAVA_JOB_STATES = {
     0x10000: {
         'friendly': "Unknown",
         'name': "JOB_STAT_UNKWN",
-        'description': "The slave batch daemon (sbatchd) on the host on which the job is processed has lost contact \
-        with the master batch daemon (mbatchd).",
+        'description': "The subordinate batch daemon (sbatchd) on the host on which the job is processed has lost contact \
+        with the main batch daemon (mbatchd).",
     },
 }
 
@@ -568,7 +568,7 @@ def gridengine_job_import(cluster, data):
         21: {
             'code': 21,
             'name': 'In recognizing job',
-            'description': 'qmaster asked about an unknown job (Not in accounting)',
+            'description': 'qmain asked about an unknown job (Not in accounting)',
             'exited_cleanly': False,
         },
         24: {
@@ -651,7 +651,7 @@ def gridengine_job_import(cluster, data):
         },
         37: {
             'code': 37,
-            'name': 'qmaster enforced h_rt, h_cpu, or h_vmem limit',
+            'name': 'qmain enforced h_rt, h_cpu, or h_vmem limit',
             'description': 'ran, but killed due to exceeding run time limit',
             'exited_cleanly': True,
         },
@@ -895,7 +895,7 @@ def univa82_job_import(cluster, data):
         21: {
             'code': 21,
             'name': 'In recognizing job',
-            'description': 'qmaster asked about an unknown job (Not in accounting)',
+            'description': 'qmain asked about an unknown job (Not in accounting)',
             'exited_cleanly': False,
         },
         24: {
@@ -978,7 +978,7 @@ def univa82_job_import(cluster, data):
         },
         37: {
             'code': 37,
-            'name': 'qmaster enforced h_rt, h_cpu, or h_vmem limit',
+            'name': 'qmain enforced h_rt, h_cpu, or h_vmem limit',
             'description': 'ran, but killed due to exceeding run time limit',
             'exited_cleanly': True,
         },

--- a/lavaflow-venv.py
+++ b/lavaflow-venv.py
@@ -18,7 +18,7 @@ import pwd
 import sys
 
 LAVAFLOW_DIST_LOCATION='https://github.com/irvined1982/lavaflow.git'
-LAVAFLOW_DIST_BRANCH='master'
+LAVAFLOW_DIST_BRANCH='main'
 
 def extend_parser(parser):
     parser.add_option(


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.